### PR TITLE
Fix segmentation fault in sum aggregation

### DIFF
--- a/libsolidity/modelcheck/model/Mapping.cpp
+++ b/libsolidity/modelcheck/model/Mapping.cpp
@@ -28,10 +28,10 @@ MapGenerator::MapGenerator(
     size_t _ct,
     TypeAnalyzer const& _converter
 ): M_LEN(_ct)
- , M_KEEP_SUM(_keep_sum && has_simple_type(*M_MAP_RECORD->value_type))
  , M_TYPE(_converter.get_type(_src))
  , M_CONVERTER(_converter)
  , M_MAP_RECORD(_converter.map_db().try_resolve(_src))
+ , M_KEEP_SUM(_keep_sum && has_simple_type(*M_MAP_RECORD->value_type))
  , M_VAL_T(_converter.get_type(*M_MAP_RECORD->value_type))
  , M_TMP(make_shared<CVarDecl>(M_TYPE, "tmp", false))
  , M_ARR(make_shared<CVarDecl>(M_TYPE, "arr", true))

--- a/libsolidity/modelcheck/model/Mapping.h
+++ b/libsolidity/modelcheck/model/Mapping.h
@@ -34,8 +34,8 @@ class MapGenerator
 public:
     // Constructs a new map. The map models AST node _src. The map will model
     // _ct entries. Its key and value types are converted using _converter,
-    // along with the map itself. Is _keep_sum is set, the sum aggregator is
-    // instrumented by default.
+    // along with the map itself. If _keep_sum is set and if the map's values
+    // have a simple type, the sum aggregator is instrumented by default.
     MapGenerator(
         Mapping const& _src,
         bool _keep_sum,
@@ -52,12 +52,14 @@ public:
 private:
     // The number of elements modeling the map.
     size_t const M_LEN;
-    bool const M_KEEP_SUM;
     std::string const M_TYPE;
 
     // Allows types to be resolved.
     TypeAnalyzer const& M_CONVERTER;
     std::shared_ptr<MapDeflate::FlatMap const> const M_MAP_RECORD;
+
+    // Maintain sum of values in maps of simple types.
+    bool const M_KEEP_SUM;
 
     // Const type names to simplify generation.
     std::string const M_VAL_T;


### PR DESCRIPTION
Fix a segmentation fault when using sum aggregation for maps that
occurs due to the use of a yet uninitialized member variable within
the MapGenerator's member initializer list.